### PR TITLE
Add a parameter to disable the execution display.

### DIFF
--- a/hailo_apps_infra/gstreamer_app.py
+++ b/hailo_apps_infra/gstreamer_app.py
@@ -96,7 +96,6 @@ class GStreamerApp:
                 self.video_source = self.video_source[0]
         self.source_type = get_source_type(self.video_source)
         self.user_data = user_data
-        self.video_sink = "autovideosink"
         self.pipeline = None
         self.loop = None
         self.threads = []
@@ -113,6 +112,12 @@ class GStreamerApp:
 
         # Set user data parameters
         user_data.use_frame = self.options_menu.use_frame
+
+        # Set status display
+        if self.options_menu.display_off == True:
+            self.video_sink = "fakevideosink"
+        else:
+            self.video_sink = "autovideosink"
 
         self.sync = "false" if (self.options_menu.disable_sync or self.source_type != "file") else "true"
         self.show_fps = self.options_menu.show_fps

--- a/hailo_apps_infra/hailo_rpi_common.py
+++ b/hailo_apps_infra/hailo_rpi_common.py
@@ -76,6 +76,7 @@ def get_default_parser():
     )
     parser.add_argument("--use-frame", "-u", action="store_true", help="Use frame from the callback function")
     parser.add_argument("--show-fps", "-f", action="store_true", help="Print FPS on sink")
+    parser.add_argument("--display-off", action="store_true", help="Disable display")
     parser.add_argument(
             "--arch",
             default=None,


### PR DESCRIPTION
Usage:
Add the --display-off parameter to disable the execution display.