### PR TITLE
Fix source detection logic in setup_env.sh for zsh compatibility

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -16,7 +16,10 @@ VENV_NAME="venv_hailo_apps"
 # Function to check if the script is being sourced
 is_sourced() {
     if [ -n "$ZSH_VERSION" ]; then
-        [[ -o sourced ]]
+        case "$ZSH_EVAL_CONTEXT" in
+            *:file*) return 0 ;;  # Match any context containing ':file'
+            *) return 1 ;;
+        esac
     elif [ -n "$BASH_VERSION" ]; then
         [[ "${BASH_SOURCE[0]}" != "$0" ]]
     else
@@ -55,7 +58,7 @@ if is_sourced; then
     }
 else
     echo "This script should be sourced, not executed directly."
-    exit 1
+    return 1 2>/dev/null || exit 1
 fi
 
 # Get the absolute path of the project's root directory (where this script is located).


### PR DESCRIPTION
### Summary

This PR fixes a compatibility issue in `setup_env.sh` where the script incorrectly detects it was not sourced when run in `zsh`, even if sourced correctly using `source setup_env.sh`.

### Fix

- Updated the `is_sourced()` function to check for any ZSH_EVAL_CONTEXT that includes `:file` in the chain
- Also safeguards the script from calling `exit` if sourced in a login shell (like over SSH)