### PR TITLE
Add RTSP camera source support to SOURCE_PIPELINE

### DIFF
--- a/hailo_apps/hailo_app_python/core/gstreamer/gstreamer_helper_pipelines.py
+++ b/hailo_apps/hailo_app_python/core/gstreamer/gstreamer_helper_pipelines.py
@@ -8,7 +8,7 @@ from hailo_apps.hailo_app_python.core.common.defines import (
 
 def get_source_type(input_source):
     # This function will return the source type based on the input source
-    # return values can be "file", "mipi" or "usb"
+    # return values can be "file", "mipi", "usb" or "rtsp"
     input_source = str(input_source)
     if input_source.startswith("/dev/video"):
         return 'usb'
@@ -18,6 +18,8 @@ def get_source_type(input_source):
         return 'libcamera'
     elif input_source.startswith('0x'):
         return 'ximage'
+    elif input_source.startswith("rtsp://") or input_source.startswith("rtspt://"):
+        return 'rtsp'
     else:
         return 'file'
 
@@ -106,6 +108,12 @@ def SOURCE_PIPELINE(video_source, video_width=640, video_height=640,
             f'{QUEUE(name=f"{name}queue_scale_")} ! '
             f'videoscale ! '
         )
+    elif source_type == 'rtsp':
+        source_element = (
+            f'uridecodebin uri="{video_source}" name={name}_udb use-buffering=false ! '
+            'videoconvert qos=false ! '
+            'videoflip name=videoflip video-direction=horiz ! '
+    )    
     else:
         source_element = (
             f'filesrc location="{video_source}" name={name} ! '


### PR DESCRIPTION
## Description

**DEV-RTSP:** Add RTSP/RTSPT camera source support to GStreamer source helpers so users can pass `rtsp://user:pass@host/path` as `--input` (e.g., IP cameras) without custom patches.

## Cause

Currently, any input that isn’t `/dev/video*`, `rpi`, `libcamera`, or `0x…` is treated as a **file** source (`filesrc … ! decodebin`). RTSP URIs need `rtspsrc` (or a URI-aware source) 

## Fix and Specs

**Files changed:**

* `hailo_apps/hailo_app_python/core/gstreamer/gstreamer_helper_pipelines.py`

  * **get\_source\_type():** detect `rtsp://` and `rtspt://` and return `'rtsp'`.
  * **SOURCE\_PIPELINE():** add an `'rtsp'` branch.

  
  * GStreamer plugins and correct auth URI format (`rtsp://user:pass@host/path`).




