### PR TITLE
Add HFLIP/VFLIP options. Minor spelling fix

### DIFF
--- a/hailo_apps/hailo_app_python/apps/detection/detection_pipeline.py
+++ b/hailo_apps/hailo_app_python/apps/detection/detection_pipeline.py
@@ -22,7 +22,7 @@ class GStreamerDetectionApp(GStreamerApp):
         parser.add_argument(
             "--labels-json",
             default=None,
-            help="Path to costume labels JSON file",
+            help="Path to custom labels JSON file",
         )
 
         # Call the parent class constructor

--- a/hailo_apps/hailo_app_python/apps/detection_simple/detection_pipeline_simple.py
+++ b/hailo_apps/hailo_app_python/apps/detection_simple/detection_pipeline_simple.py
@@ -22,7 +22,7 @@ class GStreamerDetectionApp(GStreamerApp):
         parser.add_argument(
             "--labels-json",
             default=None,
-            help="Path to costume labels JSON file",
+            help="Path to custom labels JSON file",
         )
         # Call the parent class constructor
         super().__init__(parser, user_data)

--- a/hailo_apps/hailo_app_python/core/common/core.py
+++ b/hailo_apps/hailo_app_python/core/common/core.py
@@ -100,6 +100,8 @@ def get_default_parser():
         For manually specifying a connected usb camera, use '-i /dev/video<X>' \
         Defaults to application specific video."
     )
+    parser.add_argument('--vflip', action='store_true', help='Enable vertical flip of the frame')
+    parser.add_argument('--hflip', action='store_true', help='Enable horizontal flip of the frame')
     parser.add_argument("--use-frame", "-u", action="store_true", help="Use frame from the callback function")
     parser.add_argument("--show-fps", "-f", action="store_true", help="Print FPS on sink")
     parser.add_argument(


### PR DESCRIPTION
This patch adds support for HFLIP and VFLIP at the command line. Using the Raspberry Pi 5 with a Raspberry Pi Camera module 3 (wide-angle), the video is flipped.

It changes references from "costume labels JSON file" to "custom label JSON file".