### PR TITLE
Fix compilation error by adding missing <deque> header to clip_cropper

### DIFF
--- a/hailo_apps/postprocess/cpp/clip_croppers.cpp
+++ b/hailo_apps/postprocess/cpp/clip_croppers.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <cmath>
+#include <deque>
 
 #include "clip_croppers.hpp"
 


### PR DESCRIPTION
Fix compilation error by adding missing <deque> header to clip_croppers.cpp

The clip_croppers.cpp file uses std::deque<int> on line 42 but was missing the
required #include <deque> header. This caused compilation to fail during the
post-installation step with the error:
  error: 'deque' in namespace 'std' does not name a template type

This fix adds the missing include directive to resolve the compilation error.