### PR TITLE
fix: allow CLI arguments to override config values in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1479,11 +1479,17 @@ print_summary() {
 #===============================================================================
 
 main() {
-    # Parse arguments first (before any output)
-    parse_arguments "$@"
-
     # Initialize logging
     init_logging
+
+    # Load configuration from config.yaml (required)
+    if ! load_config; then
+        log_error "Failed to load configuration. Cannot continue."
+        exit 1
+    fi
+
+    # Parse arguments AFTER config to allow CLI overrides
+    parse_arguments "$@"
 
     # Show banner
     echo ""
@@ -1499,12 +1505,6 @@ main() {
 
     # Enable error trap
     enable_error_trap
-
-    # Load configuration from config.yaml (required)
-    if ! load_config; then
-        log_error "Failed to load configuration. Cannot continue."
-        exit 1
-    fi
 
     # Show configuration summary
     log_info "Configuration:"

--- a/install.sh
+++ b/install.sh
@@ -1479,6 +1479,16 @@ print_summary() {
 #===============================================================================
 
 main() {
+    # Pre-parse for help flags to ensure they work even if config.yaml is missing
+    for arg in "$@"; do
+        case "$arg" in
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+        esac
+    done
+
     # Initialize logging
     init_logging
 


### PR DESCRIPTION
Moved `parse_arguments "$@"` to execute after `load_config` in the `main` function. Previously, variables populated by the command-line flags (such as `--venv-name` or `--no-install`) were immediately overwritten by the default values loaded from `config.yaml`.
#141 