### PR TITLE
fix: Hailo-8L detection, install.sh arg ordering, confidence bounds validation

### DIFF
--- a/hailo_apps/cpp/instance_segmentation/instance_seg_postprocess.cpp
+++ b/hailo_apps/cpp/instance_segmentation/instance_seg_postprocess.cpp
@@ -560,6 +560,21 @@ std::vector<std::pair<HailoDetection, xt::xarray<float>>> decode_boxes_and_extra
                            (decoded_box(j, 3) - decoded_box(j, 1)) / network_dims[0]);
 
             label = common::coco_eighty[class_index + 1];
+
+            // Validate confidence is in [0, 1] range.
+            // Models compiled without sigmoid activation on classification
+            // outputs may produce raw logits > 1.0, which causes
+            // HailoDetection to freeze. Clamp and warn the user.
+            if (confidence < 0.0f || confidence > 1.0f) {
+                std::fprintf(stderr,
+                    "[WARNING] Classification confidence %.4f is outside [0, 1] "
+                    "for class '%s' (index %d). This usually means the model was "
+                    "compiled without sigmoid activation on classification output "
+                    "layers. Clamping to valid range.\n",
+                    confidence, label.c_str(), class_index);
+                confidence = std::max(0.0f, std::min(1.0f, confidence));
+            }
+
             HailoDetection detected_instance(bbox, class_index, label, confidence);
 
             detections_and_masks.push_back(std::make_pair(detected_instance, mask));

--- a/install.sh
+++ b/install.sh
@@ -1488,10 +1488,7 @@ print_summary() {
 #===============================================================================
 
 main() {
-    # Parse arguments first (before any output)
-    parse_arguments "$@"
-
-    # Initialize logging
+    # Initialize logging first (needed for log_error in load_config)
     init_logging
 
     # Show banner
@@ -1501,18 +1498,24 @@ main() {
     echo -e "${CYAN}${BOLD}╚══════════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 
-    if [[ "${DRY_RUN}" == true ]]; then
-        echo -e "${MAGENTA}${BOLD}🔍 DRY-RUN MODE - No changes will be made${NC}"
-        echo ""
-    fi
-
     # Enable error trap
     enable_error_trap
 
-    # Load configuration from config.yaml (required)
+    # Load configuration from config.yaml FIRST (sets defaults)
     if ! load_config; then
         log_error "Failed to load configuration. Cannot continue."
         exit 1
+    fi
+
+    # Parse CLI arguments AFTER config, so CLI flags override config defaults.
+    # Previously parse_arguments ran first, and load_config would silently
+    # overwrite user-provided values (e.g., --all setting DOWNLOAD_GROUP="all"
+    # was overwritten to "default" by config.yaml). See issue #141.
+    parse_arguments "$@"
+
+    if [[ "${DRY_RUN}" == true ]]; then
+        echo -e "${MAGENTA}${BOLD}🔍 DRY-RUN MODE - No changes will be made${NC}"
+        echo ""
     fi
 
     # Show configuration summary

--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -74,8 +74,12 @@ detect_hailo_arch() {
                     arch="hailo8l"
                     echo "[OK]   Detected Hailo architecture: HAILO8L (via PCI device)"
                 else
+                    # NOTE: lspci does NOT reliably distinguish Hailo-8 from Hailo-8L
+                    # because 8L devices report as "Hailo-8" in PCI output (no "L" suffix).
+                    # Set tentatively; hailortcli (Method 2) will refine if available.
                     arch="hailo8"
-                    echo "[OK]   Detected Hailo architecture: HAILO8 (via PCI device)"
+                    echo "[INFO] PCI device matches Hailo-8 family (could be Hailo-8 or Hailo-8L)"
+                    echo "[INFO] Will attempt hailortcli for precise identification..."
                 fi
             elif echo "$pci_output" | grep -qiE "hailo-10|hailo10|hailo-15|hailo15"; then
                 arch="hailo10h"
@@ -90,8 +94,10 @@ detect_hailo_arch() {
                         arch="hailo8l"
                         echo "[OK]   Detected Hailo architecture: HAILO8L (via PCI device detailed info)"
                     else
+                        # Same issue: lspci -v also can't distinguish 8 from 8L
                         arch="hailo8"
-                        echo "[OK]   Detected Hailo architecture: HAILO8 (via PCI device detailed info)"
+                        echo "[INFO] PCI device matches Hailo-8 family (could be Hailo-8 or Hailo-8L)"
+                        echo "[INFO] Will attempt hailortcli for precise identification..."
                     fi
                 elif echo "$pci_detailed" | grep -qiE "hailo-10|hailo10|hailo-15|hailo15"; then
                     arch="hailo10h"
@@ -105,7 +111,9 @@ detect_hailo_arch() {
     fi
     
     # Method 2: Try hailortcli if available (most reliable when device is connected)
-    if [[ "$arch" == "unknown" ]] && command -v hailortcli >/dev/null 2>&1; then
+    # Also run when arch is "hailo8" from lspci — lspci can't distinguish 8 from 8L
+    if [[ "$arch" == "unknown" || "$arch" == "hailo8" ]] && command -v hailortcli >/dev/null 2>&1; then
+        local pci_tentative_arch="$arch"
         detection_method="hailortcli"
         local fw_output
         local fw_exit_code=0


### PR DESCRIPTION
## Summary

This PR fixes three related issues affecting Hailo device detection,
installation, and inference stability:

### 1. Hailo-8L misidentified as Hailo-8 via `lspci` (Fixes #139)

**Root cause:** `lspci` output for Hailo-8L devices does NOT contain
the `L` suffix — both 8 and 8L report as `"Hailo-8"` in PCIe device
names. The `check_installed_packages.sh` script's Method 1 (lspci)
matched `hailo-8` and confidently set `arch=hailo8`, skipping the more
reliable Method 2 (`hailortcli fw-control identify`).

**Fix:** 
- When lspci detects `Hailo-8` but NOT `Hailo-8L`, mark the detection
  as tentative instead of definitive
- Allow `hailortcli` (Method 2) to also run when `arch=hailo8` (not
  just `arch=unknown`) to refine the identification
- `hailortcli fw-control identify` correctly reports `HAILO8L` and can
  definitively distinguish the two variants

### 2. `install.sh --all` has no effect (Fixes #141)

**Root cause:** In `main()`, `parse_arguments()` was called BEFORE
`load_config()`. CLI flags like `--all` set `DOWNLOAD_GROUP=all`, but
then `load_config()` overwrote it with the config.yaml default
(`default`). This affected ALL CLI arguments.

**Fix:** Reversed the call order in `main()`:
1. `load_config()` — sets defaults from config.yaml
2. `parse_arguments()` — overrides with CLI flags

### 3. Instance segmentation freezes on confidence > 1 (Fixes #119)

**Root cause:** Models compiled without sigmoid activation on
classification output layers produce raw logits (e.g., 5.2, -1.3)
instead of probabilities in [0, 1]. The `HailoDetection` constructor
expects confidence in [0, 1] and freezes/hangs on out-of-range values.

**Fix:** Added bounds validation with clamping and a descriptive
stderr warning before constructing `HailoDetection`:
```cpp
if (confidence < 0.0f || confidence > 1.0f) {
    fprintf(stderr, "[WARNING] confidence %.4f outside [0,1]...");
    confidence = std::max(0.0f, std::min(1.0f, confidence));
}
```

## Testing

- **#139:** Verified detection flow logic: lspci match → tentative →
  hailortcli refinement path is now exercised
- **#141:** Verified `parse_arguments` runs after `load_config` and
  DRY_RUN banner is still displayed correctly
- **#119:** Verified confidence clamping prevents freeze while
  preserving valid detections

Signed-off-by: Ashutosh Kumar Singh <ashutoshkumarsingh0x@gmail.com>
