### PR TITLE
Fix Hailo-10H driver module detection

### DIFF
--- a/scripts/check_installed_packages.sh
+++ b/scripts/check_installed_packages.sh
@@ -301,28 +301,37 @@ validate_versions_for_arch() {
 }
 
 check_kernel_module() {
+    local hailo_arch="${1:-unknown}"
     local version="-1"
     local module=""
     local module_found="false"
+    local modules_to_check=()
 
-    # Try to find hailo_pci module first
-    if lsmod | grep -q "^hailo_pci "; then
-        module="hailo_pci"
-        module_found="true"
-    elif modinfo hailo_pci &>/dev/null; then
-        module="hailo_pci"
-        module_found="true"
+    if [[ "$hailo_arch" == "hailo10h" ]]; then
+        modules_to_check=("hailo1x_pci" "hailo_pci")
+    elif [[ "$hailo_arch" == "hailo8" || "$hailo_arch" == "hailo8l" ]]; then
+        modules_to_check=("hailo_pci" "hailo1x_pci")
+    else
+        modules_to_check=("hailo1x_pci" "hailo_pci")
     fi
 
-    # If hailo_pci was not found, check for hailo1x_pci
-    if [[ "$module_found" == "false" ]]; then
-        if lsmod | grep -q "^hailo1x_pci "; then
-            module="hailo1x_pci"
+    # Prefer the module that is actually loaded, then fall back to installed modules.
+    for candidate in "${modules_to_check[@]}"; do
+        if lsmod | grep -q "^$candidate "; then
+            module="$candidate"
             module_found="true"
-        elif modinfo hailo1x_pci &>/dev/null; then
-            module="hailo1x_pci"
-            module_found="true"
+            break
         fi
+    done
+
+    if [[ "$module_found" == "false" ]]; then
+        for candidate in "${modules_to_check[@]}"; do
+            if modinfo "$candidate" &>/dev/null; then
+                module="$candidate"
+                module_found="true"
+                break
+            fi
+        done
     fi
 
     # If a module was found, get its version
@@ -562,7 +571,7 @@ to_check() {
     echo ""
     
     # Display all check results for verbose output
-    kernel_output=$(check_kernel_module)
+    kernel_output=$(check_kernel_module "$hailo_arch")
     hailort_output=$(check_hailort)
     tappas_output=$(check_tappas_packages) 
     pyhailort_output=$(check_hailort_py)


### PR DESCRIPTION
## Summary
- prefer the Hailo-10H PCI driver module (`hailo1x_pci`) when checking kernel module versions on Hailo-10H systems
- keep Hailo-8/Hailo-8L behavior preferring `hailo_pci`
- prefer loaded modules before falling back to installed-but-unloaded modules

## Problem
On a Raspberry Pi 5 Hailo-10H setup, both modules can be present:

- `hailo_pci` from an older 4.23 installation, installed but not loaded
- `hailo1x_pci` 5.1.1, loaded and used by the Hailo-10H device

The prerequisite checker looked for `hailo_pci` first, reported driver version `4.23.0`, and failed Hailo-10H validation before emitting the `SUMMARY:` line. That caused `install.sh` to stop with:

```text
Could not get package summary from check script
```

## Validation
Ran locally on the affected Hailo-10H machine:

```text
Kernel Module Check:
[OK]   hailo1x_pci module loaded and installed, version: 5.1.1

Version Validation for hailo10h:
[OK]   Driver version 5.1.1 is valid for hailo10h (>= 5.0.0)
[OK]   HailoRT version 5.1.1 is valid for hailo10h (>= 5.0.0)

SUMMARY: hailo_arch=hailo10h hailo_pci=5.1.1 hailort=5.1.1 pyhailort=5.1.1 tappas-core=5.1.0 tappas-python=5.1.0
```

Also ran:

```bash
bash -n scripts/check_installed_packages.sh
```
