### PR TITLE
Add threading import to camera_utils.py

### DIFF
--- a/hailo_apps/python/core/common/camera_utils.py
+++ b/hailo_apps/python/core/common/camera_utils.py
@@ -5,6 +5,7 @@ import time
 import platform
 import cv2
 import sys
+import threading
 from enum import Enum
 from typing import Any, Optional
 import subprocess


### PR DESCRIPTION
Hi — this is my first pull request, so apologies if I've missed any conventions.
I couldn't get "./object_detection.py -n yolov8n -i rpi" to run until I made this change. It failed with:
"ERROR | common.camera_utils | Failed to open RPi camera: name 'threading' is not defined"
camera_utils.py uses threading but never imports it, so opening the RPi camera throws a NameError. This PR adds the missing import threading.
Tested on: Raspberry Pi 5 + Hailo-8, Raspberry Pi OS Trixie (Python 3.13), hailo-apps 26.3.0, HailoRT 4.23.0, TAPPAS 5.1.0.